### PR TITLE
fix: check if is connected in insufficient funds

### DIFF
--- a/src/components/AssertionForm/useAssertionForm.ts
+++ b/src/components/AssertionForm/useAssertionForm.ts
@@ -175,7 +175,9 @@ function useBond({
   chainName,
   oracleAddress,
   decimals,
+  isConnected,
 }: {
+  isConnected: boolean;
   balance: bigint;
   balanceFormatted: string;
   allowance: bigint;
@@ -192,7 +194,7 @@ function useBond({
   const bondBigInt = BigInt(parseUnits(bond as `${number}`, decimals));
   const bondFormatted = formatUnits(bondBigInt, decimals);
   const hasApproved = !!allowance && allowance >= bondBigInt;
-  const insufficientFunds = balance <= bondBigInt;
+  const insufficientFunds = isConnected && balance <= bondBigInt;
   const bondIsTooLowError =
     bondIsTooLow && minimumBond !== undefined
       ? `Bond must be at least ${formatUnits(minimumBond, decimals)} 
@@ -274,6 +276,7 @@ export function useAssertionForm() {
     bondIsTooLowError,
     insufficientFundsError,
   } = useBond({
+    isConnected,
     balance,
     balanceFormatted,
     allowance,


### PR DESCRIPTION
We need to make sure the user has connected their wallet before doing the insufficient funds check. Otherwise we end up showing the insufficient funds warning with a zero balance, when really we should just ask the user to connect.